### PR TITLE
Remove unused and superfluous imports

### DIFF
--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -2,10 +2,7 @@
 
 use super::math::*;
 use std::fmt;
-use std::{
-    convert::TryInto,
-    ops::{Index, IndexMut},
-};
+use std::ops::{Index, IndexMut};
 
 use float_cmp::{ApproxEq, F32Margin, F64Margin};
 

--- a/src/vspd.rs
+++ b/src/vspd.rs
@@ -9,7 +9,6 @@ use itertools::izip;
 
 use crate::{
     cmf::CMF,
-    illuminant,
     interpolation::{
         ExtrapolatorConstant, InterpolatorSprague, SpragueCoefficients,
     },
@@ -155,7 +154,6 @@ impl ApproxEq for Sample {
     }
 }
 
-use super::spd::SPD;
 /// A Varying Spectral Power Distribution. Stores a list of [Sample]s,
 /// i.e. paired wavelength and power values. Wavelengths are assumed to be in
 /// nanometres.


### PR DESCRIPTION
Thank you a lot for creating this library! I have not really used it yet except toying around with the examples. But I'm looking for something that allows me to convert from spectrometer measured SPDs into various color spaces, so this looks just right!

I found that just `cargo build` (on latest stable Rust) caused three warnings. So I figured I could contribute some low hanging fruit potential improvements as a start.